### PR TITLE
[WIP][Travis CI] Run specifically with sh, not bash.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 dist: trusty
 # Force travis to use its minimal image with default Python settings
-language: generic
+language: sh
 compiler:
   - gcc
 notifications:


### PR DESCRIPTION
This PR so far doesn't seem to be working as expected -- I think the following error started to happen after setting default shell as `sh` from `bash`, therefore Travis jobs should error out but the [build for this PR succeeded](https://travis-ci.org/130s/10sqft_hut/builds/205101005).

```
$ rm_dropbox_conflictfiles.sh
/home/rosnoodle/github_repos/130s/10sqft_hut/script/rm_dropbox_conflictfiles.sh: 24: /home/rosnoodle/github_repos/130s/10sqft_hut/script/rm_dropbox_conflictfiles.sh: TOPFOLDER_DROPBOX:=~/data/Dropbox: not found
#0 th file being removed:  /hom
rm: cannot remove ‘/hom’: No such file or directory
   Trying to access the same file:  /hom
ls: cannot access /hom: No such file or directory
/home/rosnoodle/github_repos/130s/10sqft_hut/script/rm_dropbox_conflictfiles.sh: 36: /home/rosnoodle/github_repos/130s/10sqft_hut/script/rm_dropbox_conflictfiles.sh: counter++: not found
#0 th file being removed:  /
rm: cannot remove ‘/’: Is a directory
   Trying to access the same file:  /
total 220K
drwxrwxrwt  47 root root 108K Feb 24 12:17 tmp
drwxr-xr-x  19 root root 4.7K Feb 24 09:12 dev
drwxr-xr-x 170 root root  12K Feb 23 03:53 etc
drwxr-xr-x  29 root root 1.2K Feb 21 20:02 run
dr-xr-xr-x  13 root root    0 Feb 17 13:15 sys
dr-xr-xr-x 378 root root    0 Feb 17 13:15 proc
drwxr-xr-x   3 root root 4.0K Feb  8 11:32 boot
drwxr-xr-x   2 root root 4.0K Feb  8 11:32 bin
drwxr-xr-x   2 root root  12K Feb  8 11:31 sbin
drwxr-xr-x  24 root root 4.0K Jan 30 14:21 .
drwxr-xr-x  24 root root 4.0K Jan 30 14:21 ..
drwxr-xr-x   2 root root 4.0K Jan 30 14:21 docker
drwxr-xr-x  16 root root 4.0K Jan 27 12:08 var
drwxr-xr-x  24 root root 4.0K Nov 17 12:14 lib
drwx------   5 root root 4.0K Oct 29 22:14 root
drwxr-xr-x   6 root root 4.0K Oct 11 18:11 opt
drwxr-xr-x  13 root root 4.0K Sep  9 13:09 usr
-rw-r--r--   1 root root   30 Aug 22  2016 config
drwxr-xr-x   4 root root 4.0K Aug  8  2016 home
drwxr-xr-x   3 root root 4.0K Jul 23  2016 media
lrwxrwxrwx   1 root root   29 Jul 14  2016 vmlinuz -> boot/vmlinuz-4.2.0-42-generic
lrwxrwxrwx   1 root root   32 Jul 14  2016 initrd.img -> boot/initrd.img-4.2.0-42-generic
lrwxrwxrwx   1 root root   29 Jun 28  2016 vmlinuz.old -> boot/vmlinuz-4.2.0-41-generic
lrwxrwxrwx   1 root root   32 Jun 28  2016 initrd.img.old -> boot/initrd.img-4.2.0-41-generic
drwxr-xr-x   2 root root 4.0K May 27  2016 lib64
drwxrwxr-x   2 root root 4.0K May 24  2016 cdrom
drwx------   2 root root  16K May 24  2016 lost+found
drwxr-xr-x   2 root root 4.0K Feb 17  2016 srv
drwxr-xr-x   2 root root 4.0K Apr 10  2014 mnt
/home/rosnoodle/github_repos/130s/10sqft_hut/script/rm_dropbox_conflictfiles.sh: 36: /home/rosnoodle/github_repos/130s/10sqft_hut/script/rm_dropbox_conflictfiles.sh: counter++: not found
#0 th file being removed:  130s/data/Dropbox/Googl
rm: cannot remove ‘130s/data/Dropbox/Googl’: No such file or directory
   Trying to access the same file:  130s/data/Dropbox/Googl
ls: cannot access 130s/data/Dropbox/Googl: No such file or directory
/home/rosnoodle/github_repos/130s/10sqft_hut/script/rm_dropbox_conflictfiles.sh: 36: /home/rosnoodle/github_repos/130s/10sqft_hut/script/rm_dropbox_conflictfiles.sh: counter++: not found
#0 th file being removed:  Driv
rm: cannot remove ‘Driv’: No such file or directory
   Trying to access the same file:  Driv
ls: cannot access Driv: No such file or directory
/home/rosnoodle/github_repos/130s/10sqft_hut/script/rm_dropbox_conflictfiles.sh: 36: /home/rosnoodle/github_repos/130s/10sqft_hut/script/rm_dropbox_conflictfiles.sh: counter++: not found
#0 th file being removed:  /gm130s_oth
rm: cannot remove ‘/gm130s_oth’: No such file or directory
   Trying to access the same file:  /gm130s_oth
ls: cannot access /gm130s_oth: No such file or directory
/home/rosnoodle/github_repos/130s/10sqft_hut/script/rm_dropbox_conflictfiles.sh: 36: /home/rosnoodle/github_repos/130s/10sqft_hut/script/rm_dropbox_conflictfiles.sh: counter++: not found
#0 th file being removed:  r/P
rm: cannot remove ‘r/P’: No such file or directory
   Trying to access the same file:  r/P
:
```
