### PR TITLE
[WIP][enhance][replace_str script] Option to exclude dir(s).

### DIFF
--- a/script/replace_str
+++ b/script/replace_str
@@ -19,10 +19,13 @@ if __name__ == "__main__":
                         help='Name of the file(s) to be manipulated.')
     parser.add_argument('-d', '--explore_depth_max', default='3',
                         help='Depth to explore. 0 for infinity.')
+    parser.add_argument('-x', '--dir_to_exclude', default='',
+                        help='Comma separated list of directories to exclude.')
     args = parser.parse_args()
 
     Util.replace_str_in_file(args.match_str_regex,
                              args.new_str,
                              args.target_path,
                              args.target_filename,
-                             int(args.explore_depth_max))
+                             int(args.explore_depth_max),
+                             args.dir_to_exclude)

--- a/script/replace_str
+++ b/script/replace_str
@@ -17,7 +17,12 @@ if __name__ == "__main__":
                         ' relative path (relative path is not tested).')
     parser.add_argument('-f', '--target_filename', default='package.xml',
                         help='Name of the file(s) to be manipulated.')
+    parser.add_argument('-d', '--explore_depth_max', default='3',
+                        help='Depth to explore. 0 for infinity.')
     args = parser.parse_args()
 
-    Util.replace_str_in_file(
-        args.match_str_regex, args.new_str, args.target_path, args.target_filename)
+    Util.replace_str_in_file(args.match_str_regex,
+                             args.new_str,
+                             args.target_path,
+                             args.target_filename,
+                             args.explore_depth_max)

--- a/script/replace_str
+++ b/script/replace_str
@@ -5,11 +5,17 @@ import argparse
 from hut_10sqft.util import Util
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Replace a line of string in all the files found at the folder tree in the given path.')
-    parser.add_argument('match_str_regex', default='<version>.*</version>', help='File pattern to match. You can use regular expression.')
+    parser = argparse.ArgumentParser(description='Replace a line of string in'
+        ' all the files found at the folder tree in the given path.')
+    parser.add_argument('match_str_regex', default='<version>.*</version>',
+        help='File pattern to match. You can use regular expression.')
     parser.add_argument('new_str', default='', help='String to be used.')
-    parser.add_argument('target_path', default='.', help='Path under which target file(s) will be searched at. Full or relative path (relative path is not tested).')
-    parser.add_argument('target_filename', default='package.xml', help='Name of the file(s) to be manipulated.')
+    parser.add_argument('-p', '--target_path', default='.', help='Path under which'
+        ' target file(s) will be searched at. Full or relative path (relative'
+        ' path is not tested).')
+    parser.add_argument('-f', '--target_filename', default='package.xml',
+        help='Name of the file(s) to be manipulated.')
     args = parser.parse_args()
 
-    Util.replace_str_in_file(args.target_filename, args.target_path, args.match_str_regex, args.new_str)
+    Util.replace_str_in_file(
+        args.target_filename, args.target_path, args.match_str_regex, args.new_str)

--- a/script/replace_str
+++ b/script/replace_str
@@ -25,4 +25,4 @@ if __name__ == "__main__":
                              args.new_str,
                              args.target_path,
                              args.target_filename,
-                             args.explore_depth_max)
+                             int(args.explore_depth_max))

--- a/script/replace_str
+++ b/script/replace_str
@@ -6,16 +6,18 @@ from hut_10sqft.util import Util
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Replace a line of string in'
-        ' all the files found at the folder tree in the given path.')
+                                     ' all the files found at the folder tree'
+                                     ' in the given path.')
     parser.add_argument('match_str_regex', default='<version>.*</version>',
-        help='File pattern to match. You can use regular expression.')
+                        help='File pattern to match. You can use regular'
+                        ' expression.')
     parser.add_argument('new_str', default='', help='String to be used.')
-    parser.add_argument('-p', '--target_path', default='.', help='Path under which'
-        ' target file(s) will be searched at. Full or relative path (relative'
-        ' path is not tested).')
+    parser.add_argument('-p', '--target_path', default='.', help='Path under '
+                        'which target file(s) will be searched at. Full or'
+                        ' relative path (relative path is not tested).')
     parser.add_argument('-f', '--target_filename', default='package.xml',
-        help='Name of the file(s) to be manipulated.')
+                        help='Name of the file(s) to be manipulated.')
     args = parser.parse_args()
 
     Util.replace_str_in_file(
-        args.target_filename, args.target_path, args.match_str_regex, args.new_str)
+        args.match_str_regex, args.new_str, args.target_path, args.target_filename)

--- a/src/hut_10sqft/util.py
+++ b/src/hut_10sqft/util.py
@@ -27,7 +27,7 @@ class Util:
 
     @staticmethod
     def find_all_files(path='.', filename_pattern='*', ret_relativepath=False,
-                       depth_max=3):
+                       dirs_to_exclude=None, depth_max=3):
         '''
         http://stackoverflow.com/questions/1724693/find-a-file-in-python
         @param path: (str) Top level path to search.
@@ -36,6 +36,8 @@ class Util:
         @param ret_relativepath: If True, returned file paths will be in
                                  relative to the "path" arg.
                                  e.g. ['file1', 'currentdir/file2']
+        @type dirs_to_exclude: [str]
+        @param dirs_to_exclude: Directories to exclude from the search.
         @param depth_max: If 0 traverse until the program ends
                           (not tested well so NOT recommended).
         @type depth_max: int
@@ -47,8 +49,19 @@ class Util:
             print('when depth_max=0: Search path: {},'
                   ' abspath: {}'.format(path, os.path.abspath(path)))
             for root, dirnames, filenames in os.walk(path):
+                print('DEBUG) root: {}\n\tdirnames: {}'.format(root, dirnames))
                 # When one or more file exists in a dir.
                 if len(filenames):
+                    if dirs_to_exclude:
+                        all_dirs = []
+                        if dirnames:
+                            all_dirs = dirnames.append(root)
+                        else:
+                            all_dirs.append(root)
+                        if [i for e in dirs_to_exclude for i in all_dirs if e in i]:
+                            # Skip when any dir name(s) found in dirs_to
+                            # exclude found in search result.
+                            continue
                     for filename in filenames:
                         _filenames.append(os.path.join(root, filename))
         else:
@@ -122,7 +135,8 @@ class Util:
                             new_str,
                             target_path='.',
                             target_filename='*',
-                            explore_depth_max=3):
+                            explore_depth_max=3,
+                            dir_to_exclude='.git'):
         '''
         @param match_str_regex: File pattern to match. You can use regular
                                 expression.
@@ -131,10 +145,17 @@ class Util:
                             at. Full or relative path.
         @param target_filename: Name of the file(s) to be manipulated.
         @param explore_depth_max: Depth to explore. 0 for infinity.
+        @type dir_to_exclude: str
+        @param dir_to_exclude: Comma separated list of directories to exclude.
+                               By default .git folder is set.
         '''
+        # Convert comma-separated str to a list
+        if dir_to_exclude:
+            dir_to_exclude = dir_to_exclude.split(',')
+
         # Find all files in sub-folders.
         files_found = Util.find_all_files(
-            target_path, target_filename, depth_max=explore_depth_max)
+            target_path, target_filename, dir_to_exclude, depth_max=explore_depth_max)
         for f in files_found:
             print('Path of the file  to be replaced: {}'.format(f))
             # replace(f, "<version>.*</version>", "<version>0.8.2</version>")

--- a/src/hut_10sqft/util.py
+++ b/src/hut_10sqft/util.py
@@ -107,8 +107,11 @@ class Util:
         file_handle.close()
 
     @staticmethod
-    def replace_str_in_file(
-            match_str_regex, new_str, target_path='.', target_filename='*'):
+    def replace_str_in_file(match_str_regex,
+                            new_str,
+                            target_path='.',
+                            target_filename='*',
+                            explore_depth_max=3):
         '''
         @param match_str_regex: File pattern to match. You can use regular
                                 expression.
@@ -116,9 +119,11 @@ class Util:
         @param target_path: Path under which target file(s) will be searched
                             at. Full or relative path.
         @param target_filename: Name of the file(s) to be manipulated.
+        @param explore_depth_max: Depth to explore. 0 for infinity.
         '''
         # Find all files in sub-folders.
-        files_found = Util.find_all_files(target_path, target_filename)
+        files_found = Util.find_all_files(
+            target_path, target_filename, depth_max=explore_depth_max)
         for f in files_found:
             print('Path of the file  to be replaced: {}'.format(f))
             # replace(f, "<version>.*</version>", "<version>0.8.2</version>")

--- a/src/hut_10sqft/util.py
+++ b/src/hut_10sqft/util.py
@@ -54,10 +54,10 @@ class Util:
             for depth in range(depth_max):
                 # Remove the last '/' to match files, not dir.
                 regex_depths = ('*/' * depth)[:-1]
-                print('regex_depths: {}'.format(regex_depths))
                 _filenames.extend(glob.glob(regex_depths))
-                print('_filenames at the moment: {}'.format(_filenames))
-
+                print('At depth {} regex_depths: {}\n\t_filenames at the'
+                      ' moment: {}'.format(depth, regex_depths, _filenames))
+        print('DEBUG) filename_pattern: {}'.format(filename_pattern))
         for filename in fnmatch.filter(_filenames, filename_pattern):
             if os.path.isdir(filename):
                 continue

--- a/src/hut_10sqft/util.py
+++ b/src/hut_10sqft/util.py
@@ -22,6 +22,7 @@ import re
 from subprocess import call
 import sys
 
+
 class Util:
 
     @staticmethod
@@ -43,7 +44,8 @@ class Util:
         filepaths_matched = []
         _filenames = []
         if depth_max == 0:
-            print('when depth_max=0: Search path: {}, abspath: {}'.format(path, os.path.abspath(path)))
+            print('when depth_max=0: Search path: {},'
+                  ' abspath: {}'.format(path, os.path.abspath(path)))
             for root, dirnames, filenames in os.walk(path):
                 if len(filenames):
                     _filenames.extend(filenames)
@@ -51,14 +53,14 @@ class Util:
         else:
             for depth in range(depth_max):
                 # Remove the last '/' to match files, not dir.
-                regex_depths =  ('*/' * depth)[:-1]
+                regex_depths = ('*/' * depth)[:-1]
                 print('regex_depths: {}'.format(regex_depths))
                 _filenames.extend(glob.glob(regex_depths))
                 print('_filenames at the moment: {}'.format(_filenames))
-            
+
         for filename in fnmatch.filter(_filenames, filename_pattern):
             if os.path.isdir(filename):
-                continue            
+                continue
             if ret_relativepath:
                 filepaths_matched.append(filename)
             else:
@@ -71,8 +73,9 @@ class Util:
     def replaceAll(file, searchExp, replaceExp):
         '''
         http://stackoverflow.com/questions/39086/search-and-replace-a-line-in-a-file-in-python
-    
-        Example usage: replaceAll("/fooBar.txt","Hello\sWorld!$","Goodbye\sWorld.")
+
+        Example usage:
+            replaceAll("/fooBar.txt","Hello\sWorld!$","Goodbye\sWorld.")
         '''
         for line in fileinput.input(file, inplace=1):
             if searchExp in line:
@@ -93,10 +96,10 @@ class Util:
         file_handle = open(filename, 'r')
         file_string = file_handle.read()
         file_handle.close()
-    
+
         # Use RE package to allow for replacement (also allowing for (multiline) REGEX)
         file_string = (re.sub(pattern, subst, file_string))
-    
+
         # Write contents to file.
         # Using mode 'w' truncates the file.
         file_handle = open(filename, 'w')
@@ -104,13 +107,16 @@ class Util:
         file_handle.close()
 
     @staticmethod
-    def replace_str_in_file(match_str_regex, new_str, target_path='.', target_filename='*'):
+    def replace_str_in_file(
+            match_str_regex, new_str, target_path='.', target_filename='*'):
         '''
-        @param match_str_regex: File pattern to match. You can use regular expression.
+        @param match_str_regex: File pattern to match. You can use regular
+                                expression.
         @param new_str: String to be used.
-        @param target_path: Path under which target file(s) will be searched at. Full or relative path.
+        @param target_path: Path under which target file(s) will be searched
+                            at. Full or relative path.
         @param target_filename: Name of the file(s) to be manipulated.
-        '''    
+        '''
         # Find all files in sub-folders.
         files_found = Util.find_all_files(target_path, target_filename)
         for f in files_found:

--- a/test/test_conf_bash.sh
+++ b/test/test_conf_bash.sh
@@ -94,7 +94,7 @@ _test_replace_py(){
 	cd $DIR_TEST
 	
 	# Command to be tested. Replace string "Isaac" with "Isao"
-	replace_str Isaac Isao . *
+	replace_str Isaac Isao -p . -f *
 	
 	# Verify the command.
 	# Success if "grep -i isaac" returns empty result.

--- a/test/test_conf_bash.sh
+++ b/test/test_conf_bash.sh
@@ -54,6 +54,13 @@ _test_androidpic_mv() {
 
     # Create folders to mimic real environment
     TARGET_FOLDER=`date -d "$D" '+%m'`;
+    # DEBUG purpose.
+    ls -al ~/link/Current
+    # To avoid the error https://github.com/130s/hut_10sqft/issues/169#issuecomment-322097088, 
+    # remove an existing symlink (only in the testcase), and re-create a folder
+    # with the same name.
+    rm ~/link/Current
+    mkdir -p ~/link/Current
     mkdir -p ~/data/Dropbox/Camera\ Uploads/ ~/data/Dropbox/SharedFromOthers/Camera\ Uploads\ from\ Mio ~/link/Current/"${TARGET_FOLDER}";
     # Populate dummy image files
     cd ~/data/Dropbox/SharedFromOthers/Camera\ Uploads\ from\ Mio

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -118,7 +118,8 @@ class TestUtil(unittest.TestCase):
                                                   depth_max=depthmax)
         # This list should be [self._TESTDATA_XML1]
         list_expected = [TestUtil._TEST_DIR + '/' + f for f in expected_files_relat]
-        print('list_expected: {}'.format(list_expected))
+        print('list_expected: {}\nfilenames_matched_3:'
+              ' {}'.format(list_expected, filenames_matched_3))
         common_list = list(set(filenames_matched_3).intersection(list_expected))
         
         if shouldfail:
@@ -134,7 +135,7 @@ class TestUtil(unittest.TestCase):
 
     def test_find_all_files_unlimiteddepth(self):
         '''Util.find_all_files with unlimited depth specified.'''
-        expected_files = [TestUtil._TESTDATA_XML1, 'prooving3.xml']
+        expected_files = [TestUtil._TESTDATA_XML1, 'depth1/depth2/depth3/depth4/depth5/depth6/depth7/prooving3.xml']
         self._test_find_all_files_filepattern(depthmax=0, expected_files_relat=expected_files)
 
     def _test_replace_str_infile(self, match_str_regex='<version>.*</version>',

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -113,8 +113,10 @@ class TestUtil(unittest.TestCase):
 
     def _test_find_all_files_filepattern(self, filename_ptn='*xml',
                                          shouldfail=False, depthmax=3,
-                                         expected_files_relat=[_TESTDATA_XML1]):
+                                         expected_files_relat=[_TESTDATA_XML1],
+                                         dirs_to_exclude='.git'):
         filenames_matched_3 = Util.find_all_files(filename_pattern=filename_ptn,
+                                                  dirs_to_exclude=dirs_to_exclude,
                                                   depth_max=depthmax)
         # This list should be [self._TESTDATA_XML1]
         list_expected = [TestUtil._TEST_DIR + '/' + f for f in expected_files_relat]
@@ -133,6 +135,23 @@ class TestUtil(unittest.TestCase):
     def test_find_all_files_filepattern_asterisk(self):
         self._test_find_all_files_filepattern()
 
+    def test_find_all_files_filepattern_exclude(self):
+        """Exclude certain directories."""
+
+        # Not includeing './depth1/.depth1/package1.xml',
+        # './depth1/depth2/depth3_2/package1.xml' that are under excluded
+        # directories.
+        EXPECTED_FILES = [TestUtil._TESTDATA_XML1]
+
+        EXCLUDE_DIRS = '.depth1,depth3_2'
+        print('[test_replace_str_infile_exclude] Excluding directories:'
+              '{}'.format(EXCLUDE_DIRS))
+        self._test_find_all_files_filepattern(
+            expected_files_relat=EXPECTED_FILES,
+            dirs_to_exclude=EXCLUDE_DIRS, depthmax=0)
+
+        self._test_find_all_files_filepattern()
+
     def test_find_all_files_unlimiteddepth(self):
         '''Util.find_all_files with unlimited depth specified.'''
         expected_files = [TestUtil._TESTDATA_XML1, 'depth1/depth2/depth3/depth4/depth5/depth6/depth7/prooving3.xml']
@@ -140,14 +159,20 @@ class TestUtil(unittest.TestCase):
 
     def _test_replace_str_infile(self, match_str_regex='<version>.*</version>',
                                  new_str='<version>100000000000</version>',
-                                 searchpath='.', filename='*'):
+                                 searchpath='.', filename='*',
+                                 dir_to_exclude='.git',
+                                 explore_depth_max=3):
         FILE_STRTEST = 'https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit/package.xml'
         testfile = urllib.URLopener()
         # Save temporarily. This method is intended for files on the filesystem.
         testfile.retrieve(FILE_STRTEST, filename)
 
         # Find all package.xml files in sub-folders.
-        Util.replace_str_in_file(match_str_regex, new_str, searchpath, filename)
+        Util.replace_str_in_file(match_str_regex,
+                                 new_str,
+                                 searchpath,
+                                 filename,
+                                 explore_depth_max=explore_depth_max)
 
         is_replaced = False
         file_strtest = open(filename).read()
@@ -173,6 +198,7 @@ class TestUtil(unittest.TestCase):
         process = Popen(['measure_performance', 'ls', '10'], stdout=PIPE, stderr=PIPE)
         stdout, stderr = process.communicate()
         self.assertTrue(stderr, '')
-
+        
+        
 if __name__ == '__main__':
     unittest.main()

--- a/test/testdata1/depth1/.depth1/package1.xml
+++ b/test/testdata1/depth1/.depth1/package1.xml
@@ -1,0 +1,6 @@
+<note>
+  <author>David Tao</author>
+  <version>4.5.6</version>
+  <title>Airport 10:30</title>
+  <body>Baby baby oh baby!</body>
+</note>

--- a/test/testdata1/depth1/depth2/depth3_2/package1.xml
+++ b/test/testdata1/depth1/depth2/depth3_2/package1.xml
@@ -1,0 +1,5 @@
+<note>
+  <author>Layla Hathaway</author>
+  <version>1.22.3</version>
+  <title>Somethin'</title>
+</note>


### PR DESCRIPTION
Without allowing to exclude directories, the script can end up manipulating files that are not supposed to be modified, e.g. those under `.git` folder.

This PR is written on top of #181.