### PR TITLE
[bash] Comment out ssh-add execution.

### DIFF
--- a/config/bash/ubuntu_common.bash
+++ b/config/bash/ubuntu_common.bash
@@ -33,4 +33,5 @@ export EDITOR=emacs
 
 # 20160716 git ssh issue https://github.com/130s/hut_10sqft/issues/64
 # Added in https://github.com/130s/hut_10sqft/pull/65
-if [ -f ~/.ssh/id_rsa ]; then ssh-add ~/.ssh/id_rsa; fi  # Key is for github
+# 20170916 To workaround https://github.com/130s/hut_10sqft/issues/67#issuecomment-330153887 upon scp, tentatively decided to comment this out. Each time accessing remote server that requires password (e.g. github.com), manually run ssh-add command (only once per terminal).
+#if [ -f ~/.ssh/id_rsa ]; then ssh-add ~/.ssh/id_rsa; fi  # Key is for github


### PR DESCRIPTION
To workaround https://github.com/130s/hut_10sqft/issues/67#issuecomment-330153887 upon scp, tentatively decided to comment this out. Each time accessing remote server that requires password (e.\
g. github.com), manually run ssh-add command (only once per terminal).

Without this change, `ssh-add` is run every time when a new terminal is opened, which is good as a reminder not to forget running it, but not having `scp` capability is more critical.