### PR TITLE
[ROS] Remove ROS_IP as it doesn't always work.

### DIFF
--- a/config/ros/setup_ros_130s-kudu1.bash
+++ b/config/ros/setup_ros_130s-kudu1.bash
@@ -3,4 +3,4 @@ DIR_THIS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export CMAKE_ECLIPSE_VERSION=4.4 # Eclipse Lunar
 
 # Requires the IP address statically assigned (by router/dhcp server etc.)
-export ROS_IP=192.168.0.15
+#export ROS_IP=192.168.0.15  # This gets tricky when a) multiple NICs are available b) dhcp isn't reliable.

--- a/config/ros/setup_ros_130s-p50.bash
+++ b/config/ros/setup_ros_130s-p50.bash
@@ -1,4 +1,1 @@
 DIR_THIS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-# Requires the IP address statically assigned (by router/dhcp server etc.)
-export ROS_IP=192.168.0.25


### PR DESCRIPTION
This gets tricky when a) multiple NICs are available b) `dhcp` isn't reliable. 